### PR TITLE
Prepare verilator 4.020

### DIFF
--- a/cpu_forwarded/stage_decode.v
+++ b/cpu_forwarded/stage_decode.v
@@ -75,8 +75,8 @@ module stage_decode(input clk,
 
    wire [31:0] reg_file_write_data;
 
-   wire [31:0]        read_data_0;
-   wire [31:0]        read_data_1;
+//   wire [31:0]        read_data_0;
+//   wire [31:0]        read_data_1;
 
    wire        reg_file_write_en;
 

--- a/cpu_forwarded/stage_decode.v
+++ b/cpu_forwarded/stage_decode.v
@@ -75,9 +75,6 @@ module stage_decode(input clk,
 
    wire [31:0] reg_file_write_data;
 
-//   wire [31:0]        read_data_0;
-//   wire [31:0]        read_data_1;
-
    wire        reg_file_write_en;
 
    pipelined_basic_register_file_control

--- a/cpu_forwarded/stage_memory.v
+++ b/cpu_forwarded/stage_memory.v
@@ -62,8 +62,8 @@ module stage_memory(
                                                   .write_enable(main_mem_wen),
                                                   .clk(clk));
 
-   wire [31:0] write_back_register_input;
-   wire [31:0] exe_result;
+//   wire [31:0] write_back_register_input;
+//   wire [31:0] exe_result;
 
    mem_result_control mem_res_control(.instr_type(current_instr_type),
                                       .read_data(read_data_1),

--- a/cpu_forwarded/stage_memory.v
+++ b/cpu_forwarded/stage_memory.v
@@ -62,9 +62,6 @@ module stage_memory(
                                                   .write_enable(main_mem_wen),
                                                   .clk(clk));
 
-//   wire [31:0] write_back_register_input;
-//   wire [31:0] exe_result;
-
    mem_result_control mem_res_control(.instr_type(current_instr_type),
                                       .read_data(read_data_1),
                                       .alu_result(alu_result),

--- a/pipelined_basic/stage_decode.v
+++ b/pipelined_basic/stage_decode.v
@@ -73,8 +73,8 @@ module stage_decode(input clk,
 
    wire [31:0] reg_file_write_data;
 
-   wire [31:0]        read_data_0;
-   wire [31:0]        read_data_1;
+//   wire [31:0]        read_data_0;
+//   wire [31:0]        read_data_1;
 
    wire        reg_file_write_en;
 

--- a/pipelined_basic/stage_decode.v
+++ b/pipelined_basic/stage_decode.v
@@ -73,9 +73,6 @@ module stage_decode(input clk,
 
    wire [31:0] reg_file_write_data;
 
-//   wire [31:0]        read_data_0;
-//   wire [31:0]        read_data_1;
-
    wire        reg_file_write_en;
 
    pipelined_basic_register_file_control

--- a/pipelined_basic/stage_memory.v
+++ b/pipelined_basic/stage_memory.v
@@ -62,8 +62,8 @@ module stage_memory(
                                                   .write_enable(main_mem_wen),
                                                   .clk(clk));
 
-   wire [31:0] write_back_register_input;
-   wire [31:0] exe_result;
+//   wire [31:0] write_back_register_input;
+//   wire [31:0] exe_result;
 
    mem_result_control mem_res_control(.instr_type(current_instr_type),
                                       .read_data(read_data_1),

--- a/pipelined_basic/stage_memory.v
+++ b/pipelined_basic/stage_memory.v
@@ -62,9 +62,6 @@ module stage_memory(
                                                   .write_enable(main_mem_wen),
                                                   .clk(clk));
 
-//   wire [31:0] write_back_register_input;
-//   wire [31:0] exe_result;
-
    mem_result_control mem_res_control(.instr_type(current_instr_type),
                                       .read_data(read_data_1),
                                       .alu_result(alu_result),


### PR DESCRIPTION
With Verilator 4.020 some errors are found during compilation like: 

```
%Error: pipelined_basic/stage_decode.v:76: Duplicate declaration of signal: 'read_data_0'
                                         : ... note: ANSI ports must have type declared with the I/O (IEEE 2017 23.2.2.2)
   wire [31:0]        read_data_0;
                      ^~~~~~~~~~~
        pipelined_basic/cpu_pipelined_basic.v:98: ... note: In file included from cpu_pipelined_basic.v
        pipelined_basic/stage_decode.v:22: ... Location of original declaration
                    output [31:0] read_data_0,
                                  ^~~~~~~~~~~
```

Test are good.